### PR TITLE
Remove logic to set the current day if its already that day

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunartick",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "",
   "main": "src/rule.js",
   "scripts": {

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -165,7 +165,10 @@ class Iterator {
     // predictable fashion and don't need to be handled separately.
     if (this.rule.frequency === 4 && this.rule.interval === 1) {
       const day = this.rule.byDay[0];
-      intervalTime.setDay(day);
+
+      if (day !== intervalTime.getDay()) {
+        intervalTime.setDay(day);
+      }
     }
 
     if (tzFromDate.isBefore(intervalTime)) {

--- a/test/sunday_test.js
+++ b/test/sunday_test.js
@@ -1,0 +1,155 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+
+const TimezoneDate = require('../src/timezone_date');
+const Iterator = require('../src/iterator');
+
+describe('Sundays', () => {
+  it('should not skip a week before the right time for weekly intervals', () => {
+    const timer = sinon.useFakeTimers(Date.UTC(2017, 3, 16, 11));
+
+    const now = new TimezoneDate();
+    expect(now.getDay()).to.equal(6);
+
+    const iterator = new Iterator({
+      frequency: 4,
+      interval: 1,
+      byDay: [6],
+      byHour: [12],
+      byMinute: [0],
+      timezone: 'Australia/Sydney',
+    }, new Date(), 5);
+
+    const next = Array.from(iterator);
+
+    expect(next[0].getMonth()).to.equal(3);
+    expect(next[0].getDate()).to.equal(16);
+    expect(next[0].getHours()).to.equal(12);
+    expect(next[0].getMinutes()).to.equal(0);
+
+    expect(next[1].getMonth()).to.equal(3);
+    expect(next[1].getDate()).to.equal(23);
+
+    expect(next[2].getMonth()).to.equal(3);
+    expect(next[2].getDate()).to.equal(30);
+
+    expect(next[3].getMonth()).to.equal(4);
+    expect(next[3].getDate()).to.equal(7);
+
+    expect(next[4].getMonth()).to.equal(4);
+    expect(next[4].getDate()).to.equal(14);
+
+    timer.restore();
+  });
+
+  it('should calculate weekly intervals correctly when the time has passed', () => {
+    const timer = sinon.useFakeTimers(Date.UTC(2017, 3, 16, 13));
+
+    const now = new TimezoneDate();
+    expect(now.getDay()).to.equal(6);
+
+    const iterator = new Iterator({
+      frequency: 4,
+      interval: 1,
+      byDay: [6],
+      byHour: [12],
+      byMinute: [0],
+      timezone: 'Australia/Sydney',
+    }, new Date(), 5);
+
+    const next = Array.from(iterator);
+
+    expect(next[0].getMonth()).to.equal(3);
+    expect(next[0].getDate()).to.equal(23);
+    expect(next[0].getHours()).to.equal(12);
+    expect(next[0].getMinutes()).to.equal(0);
+
+    expect(next[1].getMonth()).to.equal(3);
+    expect(next[1].getDate()).to.equal(30);
+
+    expect(next[2].getMonth()).to.equal(4);
+    expect(next[2].getDate()).to.equal(7);
+
+    expect(next[3].getMonth()).to.equal(4);
+    expect(next[3].getDate()).to.equal(14);
+
+    expect(next[4].getMonth()).to.equal(4);
+    expect(next[4].getDate()).to.equal(21);
+
+    timer.restore();
+  });
+
+  it('should not skip a fortnight before the right time for fortnightly intervals', () => {
+    const timer = sinon.useFakeTimers(Date.UTC(2017, 3, 16, 11));
+
+    const now = new TimezoneDate();
+    expect(now.getDay()).to.equal(6);
+
+    const iterator = new Iterator({
+      frequency: 4,
+      interval: 2,
+      byHour: [12],
+      byMinute: [0],
+      dtStart: new TimezoneDate('2017-04-16T00:00:00', 'UTC'),
+      timezone: 'Australia/Sydney',
+    }, new Date(), 5);
+
+    const next = Array.from(iterator);
+
+    expect(next[0].getMonth()).to.equal(3);
+    expect(next[0].getDate()).to.equal(16);
+    expect(next[0].getHours()).to.equal(12);
+    expect(next[0].getMinutes()).to.equal(0);
+
+    expect(next[1].getMonth()).to.equal(3);
+    expect(next[1].getDate()).to.equal(30);
+
+    expect(next[2].getMonth()).to.equal(4);
+    expect(next[2].getDate()).to.equal(14);
+
+    expect(next[3].getMonth()).to.equal(4);
+    expect(next[3].getDate()).to.equal(28);
+
+    expect(next[4].getMonth()).to.equal(5);
+    expect(next[4].getDate()).to.equal(11);
+
+    timer.restore();
+  });
+
+  it('should advance correctly after the right time for fortnightly intervals', () => {
+    const timer = sinon.useFakeTimers(Date.UTC(2017, 3, 16, 13));
+
+    const now = new TimezoneDate();
+    expect(now.getDay()).to.equal(6);
+
+    const iterator = new Iterator({
+      frequency: 4,
+      interval: 2,
+      byHour: [12],
+      byMinute: [0],
+      dtStart: new TimezoneDate('2017-04-16T00:00:00', 'UTC'),
+      timezone: 'Australia/Sydney',
+    }, new Date(), 5);
+
+    const next = Array.from(iterator);
+
+    expect(next[0].getMonth()).to.equal(3);
+    expect(next[0].getDate()).to.equal(30);
+    expect(next[0].getHours()).to.equal(12);
+    expect(next[0].getMinutes()).to.equal(0);
+
+    expect(next[1].getMonth()).to.equal(4);
+    expect(next[1].getDate()).to.equal(14);
+
+    expect(next[2].getMonth()).to.equal(4);
+    expect(next[2].getDate()).to.equal(28);
+
+    expect(next[3].getMonth()).to.equal(5);
+    expect(next[3].getDate()).to.equal(11);
+
+    expect(next[4].getMonth()).to.equal(5);
+    expect(next[4].getDate()).to.equal(25);
+
+    timer.restore();
+  });
+});

--- a/test/weekly_test.js
+++ b/test/weekly_test.js
@@ -78,7 +78,7 @@ describe('Weekly RRule iterations', () => {
     const iterator = new Iterator({
       frequency: 4,
       interval: 1,
-      byDay: [2],
+      byDay: [3],
       byHour: [12],
       byMinute: [0],
       timezone: 'UTC',
@@ -87,21 +87,21 @@ describe('Weekly RRule iterations', () => {
     const next = Array.from(iterator);
 
     expect(next[0].getMonth()).to.equal(1);
-    expect(next[0].getDate()).to.equal(8);
+    expect(next[0].getDate()).to.equal(9);
     expect(next[0].getHours()).to.equal(12);
     expect(next[0].getMinutes()).to.equal(0);
 
     expect(next[1].getMonth()).to.equal(1);
-    expect(next[1].getDate()).to.equal(15);
+    expect(next[1].getDate()).to.equal(16);
 
     expect(next[2].getMonth()).to.equal(1);
-    expect(next[2].getDate()).to.equal(22);
+    expect(next[2].getDate()).to.equal(23);
 
     expect(next[3].getMonth()).to.equal(2);
-    expect(next[3].getDate()).to.equal(1);
+    expect(next[3].getDate()).to.equal(2);
 
     expect(next[4].getMonth()).to.equal(2);
-    expect(next[4].getDate()).to.equal(8);
+    expect(next[4].getDate()).to.equal(9);
 
     timer.restore();
   });


### PR DESCRIPTION
There appears to be an issue that when you set the day of the week to Sunday when it's already Sunday, it will advance the date 7 days to the following week.

This change won't try to update the day if you're already on that day (it was unnecessary to begin with).

A few new tests have been added around Sundays to confirm this behaviour.