### PR TITLE
Fix "SECONDLY" frequency not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lunartick",
-  "version": "0.0.17",
+  "name": "@ordermentum/lunartick",
+  "version": "0.0.18",
   "description": "",
   "main": "src/rule.js",
   "scripts": {

--- a/src/parse.js
+++ b/src/parse.js
@@ -40,7 +40,7 @@ class Parse {
 
   handleFreq(arg) {
     const value = constants.FREQUENCIES[arg];
-    if (!value) {
+    if (value === undefined) {
       throw new Error(`Invalid value "${arg}" given for FREQ.`);
     }
 


### PR DESCRIPTION
If the frequency was chosen as `SECONDLY`, lunartick's parser was throwing an error because of an incorrect validation check. (0 value falsy check).